### PR TITLE
teach the parser how to handle schema value inside the opts key

### DIFF
--- a/test/analyzer/analyzer.from.test.js
+++ b/test/analyzer/analyzer.from.test.js
@@ -30,44 +30,5 @@ describe('Analyzer ::', function() {
         return done();
       });
     });
-
-    it('should generate a valid group for select when FROM is used with a SCHEMA', function(done) {
-      var tokens = tokenize({
-        select: ['title', 'author', 'year'],
-        from: { table: 'books', schema: 'foo' }
-      });
-
-      Analyzer({
-        tokens: tokens
-      })
-      .exec(function(err, result) {
-        assert(!err);
-
-        assert.deepEqual(result,  [
-          [
-            { type: 'IDENTIFIER', value: 'SELECT' },
-            { type: 'VALUE', value: 'title' }
-          ],
-          [
-            { type: 'IDENTIFIER', value: 'SELECT' },
-            { type: 'VALUE', value: 'author' }
-          ],
-          [
-            { type: 'IDENTIFIER', value: 'SELECT' },
-            { type: 'VALUE', value: 'year' }
-          ],
-          [
-            { type: 'IDENTIFIER', value: 'SCHEMA' },
-            { type: 'VALUE', value: 'foo' }
-          ],
-          [
-            { type: 'IDENTIFIER', value: 'FROM' },
-            { type: 'VALUE', value: 'books' }
-          ]
-        ]);
-
-        return done();
-      });
-    });
   });
 });

--- a/test/analyzer/analyzer.opts.schema.test.js
+++ b/test/analyzer/analyzer.opts.schema.test.js
@@ -1,0 +1,49 @@
+var Analyzer = require('../../index').analyzer;
+var tokenize = require('../support/tokenize');
+var assert = require('assert');
+
+describe('Analyzer ::', function() {
+  describe('OPTS', function() {
+    it('should generate a valid group when a SCHEMA is used', function(done) {
+      var tokens = tokenize({
+        select: ['title', 'author', 'year'],
+        from: 'books',
+        opts: {
+          schema: 'foo'
+        }
+      });
+
+      Analyzer({
+        tokens: tokens
+      })
+      .exec(function(err, result) {
+        assert(!err);
+
+        assert.deepEqual(result,  [
+          [
+            { type: 'IDENTIFIER', value: 'SELECT' },
+            { type: 'VALUE', value: 'title' }
+          ],
+          [
+            { type: 'IDENTIFIER', value: 'SELECT' },
+            { type: 'VALUE', value: 'author' }
+          ],
+          [
+            { type: 'IDENTIFIER', value: 'SELECT' },
+            { type: 'VALUE', value: 'year' }
+          ],
+          [
+            { type: 'IDENTIFIER', value: 'FROM' },
+            { type: 'VALUE', value: 'books' }
+          ],
+          [
+            { type: 'IDENTIFIER', value: 'SCHEMA' },
+            { type: 'VALUE', value: 'foo' }
+          ]
+        ]);
+
+        return done();
+      });
+    });
+  });
+});

--- a/test/tokenizer/tokenizer.opts.schema.test.js
+++ b/test/tokenizer/tokenizer.opts.schema.test.js
@@ -2,12 +2,15 @@ var Tokenizer = require('../../index').tokenizer;
 var assert = require('assert');
 
 describe('Tokenizer ::', function() {
-  describe('FROM statements', function() {
-    it('should generate a valid token array when FROM is used', function(done) {
+  describe('OPTS', function() {
+    it('should generate a valid token array when a SCHEMA is used', function(done) {
       Tokenizer({
         expression: {
-          select: '*',
-          from: 'books'
+          select: ['*'],
+          from: 'books',
+          opts: {
+            schema: 'foo'
+          }
         }
       })
       .exec(function(err, result) {
@@ -19,7 +22,10 @@ describe('Tokenizer ::', function() {
           { type: 'ENDIDENTIFIER', value: 'SELECT' },
           { type: 'IDENTIFIER', value: 'FROM' },
           { type: 'VALUE', value: 'books' },
-          { type: 'ENDIDENTIFIER', value: 'FROM' }
+          { type: 'ENDIDENTIFIER', value: 'FROM' },
+          { type: 'IDENTIFIER', value: 'SCHEMA' },
+          { type: 'VALUE', value: 'foo' },
+          { type: 'ENDIDENTIFIER', value: 'SCHEMA' }
         ]);
 
         return done();


### PR DESCRIPTION
Moved `schema` for postgres into the `opts` key. Now `from` only supports a string.
