### PR TITLE
add some parsing to build up basic joins

### DIFF
--- a/lib/converter.js
+++ b/lib/converter.js
@@ -118,6 +118,11 @@ module.exports = function convert(options) {
     if (query.avg || query.max || query.min || query.sum) {
       delete query.select;
     }
+
+    // If there are any joins add them as well
+    if (_.has(criteria, 'instructions')) {
+      processJoins(criteria);
+    }
   };
 
 
@@ -403,6 +408,52 @@ module.exports = function convert(options) {
 
     return criteria;
   };
+
+
+  //  ╔═╗╦═╗╔═╗╔═╗╔═╗╔═╗╔═╗   ┬┌─┐┬┌┐┌┌─┐
+  //  ╠═╝╠╦╝║ ║║  ║╣ ╚═╗╚═╗   ││ │││││└─┐
+  //  ╩  ╩╚═╚═╝╚═╝╚═╝╚═╝╚═╝  └┘└─┘┴┘└┘└─┘
+  //
+  // When a find query contains an instructions set build up a set of joins for
+  // the query to use.
+  var processJoins = function processJoins(criteria) {
+    if (!_.isPlainObject(criteria.instructions)) {
+      throw new Error('Join instructions are in an invalid format. They must contain a dictionary of operations.');
+    }
+    // Build an array to hold all the normalized join instructions
+    var joins = [];
+
+    _.each(criteria.instructions, function processJoinSet(join) {
+      var strategy = join.strategy && join.strategy.strategy;
+      if (!strategy) {
+        throw new Error('Join instructions are missing a valid strategy.');
+      }
+
+      _.each(join.instructions, function buildJoin(instructions) {
+        var obj = {};
+        obj.from = instructions.child;
+        obj.on = {};
+        obj.on[instructions.parent] = instructions.parentKey;
+        obj.on[instructions.child] = instructions.childKey;
+
+        // If there is a select on the instructions, move the select to the
+        // top level and append each item with the child name.
+        if (instructions.select && instructions.select.length) {
+          var _select = _.map(instructions.select, function mapSelect(col) {
+            return instructions.child + '.' + col;
+          });
+
+          // Concat the select on the main criteria
+          query.select = Array.prototype.concat(query.select, _select);
+        }
+
+        joins.push(obj);
+      });
+    });
+
+    query.leftOuterJoin = joins;
+  };
+
 
   //  ╔╗ ╦ ╦╦╦  ╔╦╗  ╔═╗ ╦ ╦╔═╗╦═╗╦ ╦
   //  ╠╩╗║ ║║║   ║║  ║═╬╗║ ║║╣ ╠╦╝╚╦╝

--- a/test/unit/converter/joins.test.js
+++ b/test/unit/converter/joins.test.js
@@ -1,0 +1,241 @@
+var Test = require('../../support/convert-runner');
+
+describe('Converter :: ', function() {
+  describe('Using Cursor Instructions (for single query situations) :: ', function() {
+    describe('With Strategy 1 :: ', function() {
+      it('should generate a find query with a left outer join', function() {
+        Test({
+          criteria: {
+            model: 'user',
+            method: 'find',
+            criteria: {
+              // Parent Criteria
+              where: {
+                type: 'beta user'
+              },
+              sort: [
+                {
+                  amount: 'DESC'
+                }
+              ],
+              // Join Instructions
+              instructions: {
+                pet: {
+                  strategy: {
+                    strategy: 1,
+                    meta: {
+                      parentFK: 'pet_id'
+                    }
+                  },
+                  instructions: [
+                    {
+                      parent: 'user',
+                      parentKey: 'pet_id',
+                      child: 'pet',
+                      childKey: 'id',
+                      alias: 'pet',
+                      removeParentKey: true,
+                      model: true,
+                      collection: false,
+                      select: ['id', 'name', 'breed'],
+                      criteria: {}
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          query: {
+            select: ['pet.id', 'pet.name', 'pet.breed'],
+            from: 'user',
+            orderBy: [
+              {
+                amount: 'DESC'
+              }
+            ],
+            where: {
+              and: [
+                {
+                  type: 'beta user'
+                }
+              ]
+            },
+            leftOuterJoin: [
+              {
+                from: 'pet',
+                on: {
+                  user: 'pet_id',
+                  pet: 'id'
+                }
+              }
+            ]
+          }
+        });
+      });
+    });
+
+    describe('With Strategy 2 :: ', function() {
+      it('should generate a find query with a left outer join', function() {
+        Test({
+          criteria: {
+            model: 'user',
+            method: 'find',
+            criteria: {
+              // Parent Criteria
+              where: {
+                type: 'beta user'
+              },
+              sort: [
+                {
+                  amount: 'DESC'
+                }
+              ],
+              // Join Instructions
+              instructions: {
+                pets: {
+                  strategy: {
+                    strategy: 2,
+                    meta: {
+                      childFK: 'user_id'
+                    }
+                  },
+                  instructions: [
+                    {
+                      parent: 'user',
+                      parentKey: 'id',
+                      child: 'pet',
+                      childKey: 'user_id',
+                      alias: 'pets',
+                      removeParentKey: true,
+                      model: false,
+                      collection: true,
+                      select: ['id', 'name', 'breed', 'user_id'],
+                      criteria: {}
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          query: {
+            select: ['pet.id', 'pet.name', 'pet.breed', 'pet.user_id'],
+            from: 'user',
+            orderBy: [
+              {
+                amount: 'DESC'
+              }
+            ],
+            where: {
+              and: [
+                {
+                  type: 'beta user'
+                }
+              ]
+            },
+            leftOuterJoin: [
+              {
+                from: 'pet',
+                on: {
+                  user: 'id',
+                  pet: 'user_id'
+                }
+              }
+            ]
+          }
+        });
+      });
+    });
+
+    describe('With Strategy 3 :: ', function() {
+      it('should generate a find query with a two left outer join clauses', function() {
+        Test({
+          criteria: {
+            model: 'user',
+            method: 'find',
+            criteria: {
+              // Parent Criteria
+              where: {
+                type: 'beta user'
+              },
+              sort: [
+                {
+                  amount: 'DESC'
+                }
+              ],
+              // Join Instructions
+              instructions: {
+                pets: {
+                  strategy: {
+                    strategy: 3,
+                    meta: {
+                      junctorIdentity: 'user_pets__pets_users',
+                      junctorPK: 'id',
+                      junctorFKToParent: 'user_pets',
+                      junctorFKToChild: 'pet_users'
+                    }
+                  },
+                  instructions: [
+                    {
+                      parent: 'user',
+                      parentKey: 'id',
+                      child: 'user_pets__pets_users',
+                      childKey: 'user_pets',
+                      alias: 'pets',
+                      removeParentKey: false,
+                      model: false,
+                      collection: true
+                    },
+                    {
+                      parent: 'user_pets__pets_users',
+                      parentKey: 'pet_users',
+                      child: 'pet',
+                      childKey: 'id',
+                      alias: 'pets',
+                      removeParentKey: false,
+                      model: false,
+                      collection: true,
+                      select: ['id', 'name', 'breed'],
+                      criteria: {}
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          query: {
+            select: ['pet.id', 'pet.name', 'pet.breed'],
+            from: 'user',
+            orderBy: [
+              {
+                amount: 'DESC'
+              }
+            ],
+            where: {
+              and: [
+                {
+                  type: 'beta user'
+                }
+              ]
+            },
+            leftOuterJoin: [
+              {
+                from: 'user_pets__pets_users',
+                on: {
+                  user: 'id',
+                  'user_pets__pets_users': 'user_pets'
+                }
+              },
+              {
+                from: 'pet',
+                on: {
+                  pet: 'id',
+                  'user_pets__pets_users': 'pet_users'
+                }
+              }
+            ]
+          }
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is only available when no join criteria is used. If there is any criteria for filtering joins then two queries will be need to made. The converter only works on a single query at a time.
