### PR TITLE
Add support for bulk inserts

### DIFF
--- a/lib/query/converter.js
+++ b/lib/query/converter.js
@@ -108,6 +108,22 @@ module.exports = function convert(options) {
   }
 
 
+  //  ╔═╗╦═╗╔═╗╔═╗╔╦╗╔═╗  ╔═╗╔═╗╔═╗╦ ╦
+  //  ║  ╠╦╝║╣ ╠═╣ ║ ║╣   ║╣ ╠═╣║  ╠═╣
+  //  ╚═╝╩╚═╚═╝╩ ╩ ╩ ╚═╝  ╚═╝╩ ╩╚═╝╩ ╩
+  //
+  // Process a CREATE EACH query and build a WQL insert query
+  var processCreateEach = function processCreateEach() {
+    query.into = model;
+    query.insert = values || [];
+
+    // Add the opts
+    if (opts) {
+      query.opts = opts;
+    }
+  };
+
+
   //  ╔═╗╦═╗╔═╗╔═╗╔╦╗╔═╗
   //  ║  ╠╦╝║╣ ╠═╣ ║ ║╣
   //  ╚═╝╩╚═╚═╝╩ ╩ ╩ ╚═╝
@@ -553,6 +569,10 @@ module.exports = function convert(options) {
     switch (method) {
       case 'create':
         processCreate();
+        break;
+
+      case 'createEach':
+        processCreateEach();
         break;
 
       case 'find':

--- a/lib/query/tokenizer.js
+++ b/lib/query/tokenizer.js
@@ -628,8 +628,40 @@ module.exports = function tokenizer(expression) {
       value: 'INSERT'
     });
 
-    // Check if a value is being used
-    if (_.isObject(value)) {
+    // Check if an array is being used
+    if (_.isArray(value)) {
+      _.each(value, function appendInsertEach(record, idx) {
+        // Add a group clause
+        results.push({
+          type: 'GROUP',
+          value: idx
+        });
+
+        // If the value is a plain object, proccess it
+        if (_.isPlainObject(record)) {
+          _.each(_.keys(record), function appendInsertValue(key) {
+            results.push({
+              type: 'KEY',
+              value: key
+            });
+
+            results.push({
+              type: 'VALUE',
+              value: record[key]
+            });
+          });
+        }
+
+        // Close the group clause
+        results.push({
+          type: 'ENDGROUP',
+          value: idx
+        });
+      });
+    }
+
+    // Check if a plain object value is being used
+    if (_.isPlainObject(value)) {
       _.each(_.keys(value), function appendInsertValue(key) {
         results.push({
           type: 'KEY',

--- a/test/unit/analyzer/analyzer.insert.test.js
+++ b/test/unit/analyzer/analyzer.insert.test.js
@@ -26,5 +26,44 @@ describe('Analyzer ::', function() {
         ]
       ]);
     });
+
+    it('should generate a valid group for INSERT statements when an array is used', function() {
+      var tokens = tokenize({
+        insert: [
+          {
+            title: 'Slaughterhouse Five',
+            author: 'Kurt Vonnegut'
+          },
+          {
+            title: 'The Great Gatsby',
+            author: 'F. Scott Fitzgerald'
+          }
+        ],
+        into: 'books'
+      });
+
+      var result = Analyzer(tokens);
+      assert.deepEqual(result, [
+        [
+          { type: 'IDENTIFIER', value: 'INSERT' },
+          [
+            { type: 'KEY', value: 'title' },
+            { type: 'VALUE', value: 'Slaughterhouse Five' },
+            { type: 'KEY', value: 'author' },
+            { type: 'VALUE', value: 'Kurt Vonnegut' }
+          ],
+          [
+            { type: 'KEY', value: 'title' },
+            { type: 'VALUE', value: 'The Great Gatsby' },
+            { type: 'KEY', value: 'author' },
+            { type: 'VALUE', value: 'F. Scott Fitzgerald' }
+          ]
+        ],
+        [
+          { type: 'IDENTIFIER', value: 'INTO' },
+          { type: 'VALUE', value: 'books' }
+        ]
+      ]);
+    });
   });
 });

--- a/test/unit/converter/create-each.test.js
+++ b/test/unit/converter/create-each.test.js
@@ -1,0 +1,33 @@
+var Test = require('../../support/convert-runner');
+
+describe('Converter :: ', function() {
+  describe('Create Each :: ', function() {
+    it('should generate a create each query', function() {
+      Test({
+        criteria: {
+          model: 'user',
+          method: 'createEach',
+          values: [
+            {
+              firstName: 'foo'
+            },
+            {
+              firstName: 'bar'
+            }
+          ]
+        },
+        query: {
+          insert: [
+            {
+              firstName: 'foo'
+            },
+            {
+              firstName: 'bar'
+            }
+          ],
+          into: 'user'
+        }
+      });
+    });
+  });
+});

--- a/test/unit/tokenizer/tokenizer.aggregations.test.js
+++ b/test/unit/tokenizer/tokenizer.aggregations.test.js
@@ -3,58 +3,6 @@ var assert = require('assert');
 
 describe('Tokenizer ::', function() {
   describe('Aggregations', function() {
-    it('should generate a valid token array for GROUP BY', function() {
-      var result = Tokenizer({
-        select: ['*'],
-        from: 'users',
-        groupBy: 'count'
-      });
-
-      assert.deepEqual(result, [
-        { type: 'IDENTIFIER', value: 'SELECT' },
-        { type: 'VALUE', value: '*' },
-        { type: 'ENDIDENTIFIER', value: 'SELECT' },
-        { type: 'IDENTIFIER', value: 'FROM' },
-        { type: 'VALUE', value: 'users' },
-        { type: 'ENDIDENTIFIER', value: 'FROM' },
-        { type: 'IDENTIFIER', value: 'GROUPBY' },
-        { type: 'VALUE', value: 'count' },
-        { type: 'ENDIDENTIFIER', value: 'GROUPBY' }
-      ]);
-    });
-
-    it('should generate a valid token array when MIN is used', function() {
-      var result = Tokenizer({
-        min: 'active',
-        from: 'users'
-      });
-
-      assert.deepEqual(result,  [
-        { type: 'IDENTIFIER', value: 'MIN' },
-        { type: 'VALUE', value: 'active' },
-        { type: 'ENDIDENTIFIER', value: 'MIN' },
-        { type: 'IDENTIFIER', value: 'FROM' },
-        { type: 'VALUE', value: 'users' },
-        { type: 'ENDIDENTIFIER', value: 'FROM' }
-      ]);
-    });
-
-    it('should generate a valid token array when MAX is used', function() {
-      var result = Tokenizer({
-        max: 'active',
-        from: 'users'
-      });
-
-      assert.deepEqual(result,  [
-        { type: 'IDENTIFIER', value: 'MAX' },
-        { type: 'VALUE', value: 'active' },
-        { type: 'ENDIDENTIFIER', value: 'MAX' },
-        { type: 'IDENTIFIER', value: 'FROM' },
-        { type: 'VALUE', value: 'users' },
-        { type: 'ENDIDENTIFIER', value: 'FROM' }
-      ]);
-    });
-
     it('should generate a valid token array when SUM is used', function() {
       var result = Tokenizer({
         sum: 'active',

--- a/test/unit/tokenizer/tokenizer.count.test.js
+++ b/test/unit/tokenizer/tokenizer.count.test.js
@@ -5,13 +5,13 @@ describe('Tokenizer ::', function() {
   describe('COUNT statements', function() {
     it('should generate a valid token array when COUNT is used', function() {
       var result = Tokenizer({
-        count: 'active',
+        count: true,
         from: 'users'
       });
 
       assert.deepEqual(result,  [
         { type: 'IDENTIFIER', value: 'COUNT' },
-        { type: 'VALUE', value: 'active' },
+        { type: 'VALUE', value: true },
         { type: 'ENDIDENTIFIER', value: 'COUNT' },
         { type: 'IDENTIFIER', value: 'FROM' },
         { type: 'VALUE', value: 'users' },

--- a/test/unit/tokenizer/tokenizer.insert.test.js
+++ b/test/unit/tokenizer/tokenizer.insert.test.js
@@ -21,5 +21,35 @@ describe('Tokenizer ::', function() {
         { type: 'ENDIDENTIFIER', value: 'INTO' }
       ]);
     });
+
+    it('should generate a valid token array for an INSERT is used as an array', function() {
+      var result = Tokenizer({
+        insert: [
+          {
+            title: 'Slaughterhouse Five'
+          },
+          {
+            title: 'The Great Gatsby'
+          }
+        ],
+        into: 'books'
+      });
+
+      assert.deepEqual(result, [
+        { type: 'IDENTIFIER', value: 'INSERT' },
+        { type: 'GROUP', value: 0 },
+        { type: 'KEY', value: 'title' },
+        { type: 'VALUE', value: 'Slaughterhouse Five' },
+        { type: 'ENDGROUP', value: 0 },
+        { type: 'GROUP', value: 1 },
+        { type: 'KEY', value: 'title' },
+        { type: 'VALUE', value: 'The Great Gatsby' },
+        { type: 'ENDGROUP', value: 1 },
+        { type: 'ENDIDENTIFIER', value: 'INSERT' },
+        { type: 'IDENTIFIER', value: 'INTO' },
+        { type: 'VALUE', value: 'books' },
+        { type: 'ENDIDENTIFIER', value: 'INTO' }
+      ]);
+    });
   });
 });


### PR DESCRIPTION
Allow for bulk inserts to be generated using a single query. This will become the native implementation of `createEach`.