### PR TITLE
Default "primaryKeyColumnName" to attribute name

### DIFF
--- a/lib/auto-migrations/strategies/alter.js
+++ b/lib/auto-migrations/strategies/alter.js
@@ -121,7 +121,7 @@ module.exports = function alterStrategy(orm, cb) {
             }
 
             var lastRecord = _.last(backupRecords);
-            var primaryKeyColumnName = WLModel.schema[primaryKeyAttrName].columnName;
+            var primaryKeyColumnName = WLModel.schema[primaryKeyAttrName].columnName || primaryKeyAttrName;
             var sequenceName = WLModel.tableName + '_' + primaryKeyColumnName + '_seq';
             var sequenceValue = lastRecord[primaryKeyColumnName];
 


### PR DESCRIPTION
Without this, I get errors when lifting Sails the second time w/ a Postgres datastore, after performing steps 1-3 in https://gist.github.com/sgress454/6dc5561b668b28ff0f8abff5f53d7e46#repro.