### PR TITLE
Always use `columnName`, and always get it from the model schema

### DIFF
--- a/lib/auto-migrations/strategies/alter.js
+++ b/lib/auto-migrations/strategies/alter.js
@@ -45,7 +45,7 @@ module.exports = function alterStrategy(orm, cb) {
     // Build a schema to represent the underlying physical database structure
     var schema = {};
     _.each(WLModel.schema, function parseAttribute(attributeVal, attributeName) {
-      var columnName = attributeVal.columnName || attributeName;
+      var columnName = attributeVal.columnName;
 
       // If the attribute doesn't have an `autoMigrations` key on it, ignore it.
       if (!_.has(attributeVal, 'autoMigrations')) {
@@ -57,9 +57,9 @@ module.exports = function alterStrategy(orm, cb) {
 
     // Set Primary Key flag on the primary key attribute
     var primaryKeyAttrName = WLModel.primaryKey;
-    var primaryKey = WLModel.attributes[primaryKeyAttrName];
+    var primaryKey = WLModel.schema[primaryKeyAttrName];
     if (primaryKey) {
-      var pkColumnName = primaryKey.columnName || primaryKeyAttrName;
+      var pkColumnName = primaryKey.columnName;
       schema[pkColumnName].primaryKey = true;
     }
 


### PR DESCRIPTION
wl-schema has been updated to _always_ provide a columnName, so the `||` should no longer be necessary.  But `columnName` only exists in the `.schema`, not in the `.attributes`