### PR TITLE
Don't use `WLModel.adapterDictionary`

### DIFF
--- a/lib/auto-migrations/strategies/alter.js
+++ b/lib/auto-migrations/strategies/alter.js
@@ -26,7 +26,7 @@ module.exports = function alterStrategy(orm, cb) {
     var WLModel = orm.collections[collectionName];
 
     // Grab the adapter to perform the query on
-    var datastoreName = WLModel.adapterDictionary.update;
+    var datastoreName = WLModel.datastore;
     var WLAdapter = orm.datastores[datastoreName].adapter;
 
     // Set a tableName to use

--- a/lib/auto-migrations/strategies/drop.js
+++ b/lib/auto-migrations/strategies/drop.js
@@ -20,7 +20,7 @@ module.exports = function dropStrategy(orm, cb) {
     var WLModel = orm.collections[collectionName];
 
     // Grab the adapter to perform the query on
-    var datastoreName = WLModel.adapterDictionary.update;
+    var datastoreName = WLModel.datastore;
     var WLAdapter = orm.datastores[datastoreName].adapter;
 
     // Set a tableName to use


### PR DESCRIPTION
This expects the `Model.datastore` to always be a string; see https://github.com/balderdashy/sails-hook-orm/commit/3571807d5f1708b0bd926fc0c2871aa21bc57203