### PR TITLE
Create the .tmp directory if it doesn't already exist.

### DIFF
--- a/lib/auto-migrations/private/run-alter-strategy/private/inform-re-failed-alter-stratagem.js
+++ b/lib/auto-migrations/private/run-alter-strategy/private/inform-re-failed-alter-stratagem.js
@@ -2,11 +2,11 @@
  * Module dependencies
  */
 
-var fs = require('fs');
 var path = require('path');
 var util = require('util');
 var _ = require('@sailshq/lodash');
 var flaverr = require('flaverr');
+var fsx = require('fs-extra');
 
 /**
  * informReFailedAlterStratagem()
@@ -166,7 +166,8 @@ module.exports = function informReFailedAlterStratagem(err, operationName, model
   logFileContents += 'http://sailsjs.com/support\n';
   logFileContents += '\n';
 
-  fs.writeFile(absPathToLogFile, logFileContents, function (err) {
+  // (see https://github.com/jprichardson/node-fs-extra/tree/0.30.0#outputfilefile-data-options-callback)
+  fsx.outputFile(absPathToLogFile, logFileContents, function (err) {
     if (err) {
       console.error('\n'+
         'WARNING: Temporary log file w/ recovered dev data could not actually be written to disk!\n'+

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@sailshq/lodash": "^3.10.2",
     "async": "2.0.1",
-    "flaverr": "^1.1.1"
+    "flaverr": "^1.1.1",
+    "fs-extra": "0.30.0"
   },
   "devDependencies": {
     "benchmark": "2.1.1",


### PR DESCRIPTION
Note that this adds a dependency.  But the footprint is super minor:


#### Before

```
waterline-utils: ∑ kit deps
  flaverr@1.1.1             9.23 KB    0.004 seconds
  @sailshq/lodash@3.10.2    428.05 KB  0.214 seconds
  async@2.0.1               1.82 MB    0.912 seconds

Altogether, dependencies weigh in at 2.26 MB
(that will take an average of 1.13 seconds on coffee shop internet)

 (Note that `devDependencies` and `optionalDependencies` were NOT included above.)
```

#### After

```
waterline-utils: ∑ kit deps
  flaverr@1.1.1             9.23 KB    0.004 seconds
  @sailshq/lodash@3.10.2    428.05 KB  0.214 seconds
  async@2.0.1               1.82 MB    0.912 seconds
  fs-extra@0.30.0           357.4 KB   0.178 seconds

Altogether, dependencies weigh in at 2.62 MB
(that will take an average of 1.31 seconds on coffee shop internet)

 (Note that `devDependencies` and `optionalDependencies` were NOT included above.)
```

#### Feature(s) used from new dep.

| Feature         | Benefit    |
|:-------------|:----------------|
| [fsx.outputFile()](https://github.com/jprichardson/node-fs-extra/tree/0.30.0#outputfilefile-data-options-callback) | Deals with race conditions and gracefully creates the file, ensuring any necessary intermediate directories.

