### PR TITLE
Add `!=` and `nin` to list of reserved keys that don't get expanded when using native joins.

### DIFF
--- a/lib/joins/private/expand-criteria.js
+++ b/lib/joins/private/expand-criteria.js
@@ -44,7 +44,9 @@ module.exports = function expandCriteria(originalCriteria, tableName) {
     'or',
     'and',
     'not',
-    'like'
+    'like',
+    '!=',
+    'nin'
   ];
 
 


### PR DESCRIPTION
refs https://github.com/balderdashy/waterline/issues/1482