### PR TITLE
Remove explicit escaping of string values.

### DIFF
--- a/lib/query/tokenizer.js
+++ b/lib/query/tokenizer.js
@@ -92,35 +92,6 @@ var DML_IDENTIFIERS = [
   'del'
 ];
 
-//  ╔═╗╔═╗╔═╗╔═╗╔═╗╔═╗  ┌─┐┌─┐ ┬    ┌─┐┌┬┐┬─┐┬┌┐┌┌─┐┌─┐
-//  ║╣ ╚═╗║  ╠═╣╠═╝║╣   └─┐│─┼┐│    └─┐ │ ├┬┘│││││ ┬└─┐
-//  ╚═╝╚═╝╚═╝╩ ╩╩  ╚═╝  └─┘└─┘└┴─┘  └─┘ ┴ ┴└─┴┘└┘└─┘└─┘
-var escaper = function escaper(str) {
-  return str.replace(/[\0\x08\x09\x1a\n\r"'\\\%]/g, function replace(char) {
-    switch (char) {
-      case '\0':
-        return '\\0';
-      case '\x08':
-        return '\\b';
-      case '\x09':
-        return '\\t';
-      case '\x1a':
-        return '\\z';
-      case '\n':
-        return '\\n';
-      case '\r':
-        return '\\r';
-      case '\"':
-      case '\'':
-      case '\\':
-      case '%':
-        // prepends a backslash to backslash, percent,
-        // and double/single quotes
-        return '\\' + char;
-    }
-  });
-};
-
 //  ╔╦╗╔═╗╦╔═╔═╗╔╗╔╦╔═╗╔═╗  ┌─┐┌┐  ┬┌─┐┌─┐┌┬┐
 //   ║ ║ ║╠╩╗║╣ ║║║║╔═╝║╣   │ │├┴┐ │├┤ │   │
 //   ╩ ╚═╝╩ ╩╚═╝╝╚╝╩╚═╝╚═╝  └─┘└─┘└┘└─┘└─┘ ┴
@@ -459,11 +430,6 @@ var tokenizeObject = function tokenizeObject(obj, processor, parent, isSubQuery,
       return;
     }
 
-    // Otherwise just add the value
-    if (_.isString(obj[key])) {
-      obj[key] = escaper(obj[key]);
-    }
-
     // If the value is a primitive add it's token
     results.push({
       type: 'VALUE',
@@ -527,11 +493,6 @@ var processOperator = function processOperator(operator, value, results) {
     type: 'OPERATOR',
     value: operator
   });
-
-  // Add the value to the results
-  if (_.isString(value) && operator !== 'like') {
-    value = escaper(value);
-  }
 
   results.push({
     type: 'VALUE',
@@ -884,11 +845,6 @@ var processNot = function processNot(value, results) {
     return;
   }
 
-  // Otherwise just add the value
-  if (_.isString(value)) {
-    value = escaper(value);
-  }
-
   results.push({
     type: 'VALUE',
     value: value
@@ -935,11 +891,6 @@ var processIn = function processIn(value, negate, results) {
 
   // If the value isn't an object, no need to process it further
   if (!_.isPlainObject(value)) {
-    // Otherwise just add the value
-    if (_.isString(value)) {
-      value = escaper(value);
-    }
-
     results.push({
       type: 'VALUE',
       value: value


### PR DESCRIPTION
The two main SQL drivers (machinepack-postgresql and machinepack-mysql) both use parameterized queries, so escaping isn't necessary.  Furthermore the escaping breaks queries for strings with special characters (like quotes) in them.

e.g. 
```
Company.find({name: 'Bert\'s bees'})
```

will never return any records because of the escaping.  This can be verified using the new tests in waterline-adapter-tests introduced in https://github.com/balderdashy/waterline-adapter-tests//commit/19dbf705b102af044d8e5b05de76df5d100e3a92