### PR TITLE
Always disambiguate child criteria in joins

### DIFF
--- a/lib/joins/convert-join-criteria.js
+++ b/lib/joins/convert-join-criteria.js
@@ -553,6 +553,26 @@ module.exports = function convertCriteria(options) {
     // Check if the child is paginated
     var childPaginated = _.has(childInstructions.criteria, 'skip') || _.has(childInstructions.criteria, 'limit');
 
+    // Ensure the criteria has a WHERE clause to make it valid
+    if (!_.has(childInstructions.criteria, 'where')) {
+      childInstructions.criteria.where = {};
+    }
+
+    // Ensure that child criteria are namespaced to the child alias, to avoid collisions
+    // with fields in the join table (most likely `id`).
+    childInstructions.criteria.where = (function disambiguate(obj) {
+      return _.reduce(obj, function(memo, val, key) {
+        if (key === 'and' || key === 'or') {
+          memo[key] = _.map(val, disambiguate);
+        }
+        else {
+          memo[childInstructions.childAlias + '.' + key] = val;
+        }
+        return memo;
+      }, {});
+    })(childInstructions.criteria.where);
+
+
 
     //  ╔═╗╔═╗╔╗╔╔═╗╦═╗╔═╗╔╦╗╔═╗  ┌┐┌┌─┐┌┐┌   ┌─┐┌─┐┌─┐┬┌┐┌┌─┐┌┬┐┌─┐┌┬┐
     //  ║ ╦║╣ ║║║║╣ ╠╦╝╠═╣ ║ ║╣   ││││ ││││───├─┘├─┤│ ┬││││├─┤ │ ├┤  ││
@@ -563,10 +583,6 @@ module.exports = function convertCriteria(options) {
     // If the join criteria isn't paginated an IN query can be used.
     if (strategy === 3 && !childPaginated) {
       (function generateTemplate() {
-        // Ensure the criteria has a WHERE clause to make it valid
-        if (!_.has(childInstructions.criteria, 'where')) {
-          childInstructions.criteria.where = {};
-        }
 
         // The WHERE IN template for many to many queries is a little bit different.
         // Instead of using the primary key of the parent the parent key of the
@@ -638,10 +654,6 @@ module.exports = function convertCriteria(options) {
     // must be built.
     if (strategy === 3 && childPaginated) {
       (function generateTemplate() {
-        // Ensure the criteria has a WHERE clause to make it valid
-        if (!_.has(childInstructions.criteria, 'where')) {
-          childInstructions.criteria.where = {};
-        }
 
         var modifiedInstructions =  _.merge({}, _instructions);
         modifiedInstructions.instructions = [childInstructions];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "waterline-utils",
-  "version": "1.3.17",
+  "version": "1.3.18",
   "description": "Various utilities for working with Waterline queries and adapters.",
   "scripts": {
     "test": "node ./node_modules/mocha/bin/mocha test/unit --recursive",


### PR DESCRIPTION
This avoids conflicts between the child table (e.g. `pets`) and the join table (e.g. `pet_owners__user_pets__pets`) on fields they share -- usually `id`, but nothing's stopping you from declaring an attribute like `user_pets` in your `pets` table, either...

refs https://trello.com/c/hqKKvZUB