### PR TITLE
Enable ORM to accept attributes named 'length'

### DIFF
--- a/lib/joins/detect-children-records.js
+++ b/lib/joins/detect-children-records.js
@@ -44,7 +44,7 @@ module.exports = function detectChildrenRecords(primaryKeyAttr, records) {
 
     // Process each key in the record and build up a child record that can
     // then be nested into the parent.
-    _.each(record, function checkForChildren(val, key) {
+    _.forIn(record, function checkForChildren(val, key) {
       // Check if the key can be split this on the special alias identifier '__' (two underscores).
       var split = key.split('__');
       if (split.length < 2) {


### PR DESCRIPTION
Replace `_.each()` with `_.forIn()` to enable ORM to accept attributes named 'length'.

See https://github.com/balderdashy/sails/issues/4353