### PR TITLE
updates to support datastore specific migrations

### DIFF
--- a/lib/auto-migrations/index.js
+++ b/lib/auto-migrations/index.js
@@ -20,6 +20,7 @@ var runSafeStrategy = require('./private/run-safe-strategy');
  */
 module.exports = function runAutoMigrations(strategy, orm, cb) {
 
+  // Ensure a callback function exists
   cb = cb || function (err, response) {
     if (err) { console.error(err); }
     return response;
@@ -38,11 +39,6 @@ module.exports = function runAutoMigrations(strategy, orm, cb) {
   if (!orm || !_.isObject(orm)) {
     return cb(new Error('ORM must be an initialized Waterline ORM instance.'));
   }
-
-  // Ensure a callback function exists
-  // if (!cb || !_.isFunction(cb)) {
-  //   throw new Error('Missing callback argument.');
-  // }
 
   //  ╦═╗╦ ╦╔╗╔  ┌┬┐┬┌─┐┬─┐┌─┐┌┬┐┬┌─┐┌┐┌  ┌─┐┌┬┐┬─┐┌─┐┌┬┐┌─┐┌─┐┬ ┬
   //  ╠╦╝║ ║║║║  │││││ ┬├┬┘├─┤ │ ││ ││││  └─┐ │ ├┬┘├─┤ │ ├┤ │ ┬└┬┘

--- a/lib/auto-migrations/index.js
+++ b/lib/auto-migrations/index.js
@@ -19,6 +19,12 @@ var runSafeStrategy = require('./private/run-safe-strategy');
  * @return {[type]}            [description]
  */
 module.exports = function runAutoMigrations(strategy, orm, cb) {
+
+  cb = cb || function (err, response) {
+    if (err) { console.error(err); }
+    return response;
+  };
+
   //  ╦  ╦╔═╗╦  ╦╔╦╗╔═╗╔╦╗╔═╗  ┌─┐┌┬┐┬─┐┌─┐┌┬┐┌─┐┌─┐┬ ┬
   //  ╚╗╔╝╠═╣║  ║ ║║╠═╣ ║ ║╣   └─┐ │ ├┬┘├─┤ │ ├┤ │ ┬└┬┘
   //   ╚╝ ╩ ╩╩═╝╩═╩╝╩ ╩ ╩ ╚═╝  └─┘ ┴ ┴└─┴ ┴ ┴ └─┘└─┘ ┴
@@ -34,17 +40,17 @@ module.exports = function runAutoMigrations(strategy, orm, cb) {
   }
 
   // Ensure a callback function exists
-  if (!cb || !_.isFunction(cb)) {
-    throw new Error('Missing callback argument.');
-  }
+  // if (!cb || !_.isFunction(cb)) {
+  //   throw new Error('Missing callback argument.');
+  // }
 
   //  ╦═╗╦ ╦╔╗╔  ┌┬┐┬┌─┐┬─┐┌─┐┌┬┐┬┌─┐┌┐┌  ┌─┐┌┬┐┬─┐┌─┐┌┬┐┌─┐┌─┐┬ ┬
   //  ╠╦╝║ ║║║║  │││││ ┬├┬┘├─┤ │ ││ ││││  └─┐ │ ├┬┘├─┤ │ ├┤ │ ┬└┬┘
   //  ╩╚═╚═╝╝╚╝  ┴ ┴┴└─┘┴└─┴ ┴ ┴ ┴└─┘┘└┘  └─┘ ┴ ┴└─┴ ┴ ┴ └─┘└─┘ ┴
   switch(strategy){
-    case 'alter': runAlterStrategy(orm, cb); break;
-    case 'drop': runDropStrategy(orm, cb); break;
-    case 'safe': runSafeStrategy(orm, cb); break;
+    case 'alter': return runAlterStrategy(orm, cb);
+    case 'drop': return runDropStrategy(orm, cb);
+    case 'safe': return runSafeStrategy(orm, cb);
     default: return cb(new Error('Strategy must be one of: `alter`, `drop`, or `safe`.'));
   }
 };

--- a/lib/auto-migrations/private/run-alter-strategy/index.js
+++ b/lib/auto-migrations/private/run-alter-strategy/index.js
@@ -206,9 +206,9 @@ module.exports = function runAlterStrategy(orm, cb) {
     });//</ find >
   }, function afterMigrate(err) {
     if (err) {
-      return cb(err);
+      return Promise.reject(err); // cb(err);
     }
 
-    return cb();
+    return Promise.resolve(); // cb();
   });
 };

--- a/lib/auto-migrations/private/run-alter-strategy/index.js
+++ b/lib/auto-migrations/private/run-alter-strategy/index.js
@@ -206,9 +206,9 @@ module.exports = function runAlterStrategy(orm, cb) {
     });//</ find >
   }, function afterMigrate(err) {
     if (err) {
-      return Promise.reject(err); // cb(err);
+      return Promise.reject(err);
     }
 
-    return Promise.resolve(); // cb();
-  });
-};
+    return Promise.resolve();
+  })
+}

--- a/lib/auto-migrations/private/run-drop-strategy.js
+++ b/lib/auto-migrations/private/run-drop-strategy.js
@@ -74,9 +74,9 @@ module.exports = function dropStrategy(orm, cb) {
     });
   }, function afterMigrate(err) {
     if (err) {
-      return cb(err);
+      return Promise.reject(err);
     }
 
-    return cb();
+    return Promise.resolve();
   });
 };

--- a/lib/auto-migrations/private/run-safe-strategy.js
+++ b/lib/auto-migrations/private/run-safe-strategy.js
@@ -9,6 +9,6 @@
 
 module.exports = function safeStrategy(orm, cb) {
   return setImmediate(function ensureAsync() {
-    return cb();
+    return Promise.resolve();
   });
 };


### PR DESCRIPTION
- made the migration types functions return promises so we can Promise.all elsewhere
- made it not require a callback
