### PR TITLE
Fixes incorrect joins table columns if the attribute name contains double underscore

### DIFF
--- a/lib/joins/detect-children-records.js
+++ b/lib/joins/detect-children-records.js
@@ -46,13 +46,13 @@ module.exports = function detectChildrenRecords(primaryKeyAttr, records) {
     // then be nested into the parent.
     _.forIn(record, function checkForChildren(val, key) {
       // Check if the key can be split this on the special alias identifier '__' (two underscores).
-      var split = key.split('__');
-      if (split.length < 2) {
+      var aliasIndex = key.indexOf('__');
+      if (aliasIndex <= 0 ) {
         return;
       }
 
-      var alias = _.first(split);
-      var attribute = _.last(split);
+      var alias = key.substring(0, aliasIndex);
+      var attribute = key.substring(aliasIndex + 2);
 
       // Make sure the local cache knows about this child (i.e. the populated alias name - pets).
       if (!_.has(cache, alias)) {

--- a/test/support/detectchildren-runner.js
+++ b/test/support/detectchildren-runner.js
@@ -1,0 +1,7 @@
+var assert = require('assert');
+var DetectChildren = require('../../lib/joins/detect-children-records');
+
+module.exports = function(test) {
+  var result = DetectChildren(test.primaryKeyAttr, test.records);
+  assert.deepEqual(result, test.expected);
+};

--- a/test/unit/converter/detectchildren.test.js
+++ b/test/unit/converter/detectchildren.test.js
@@ -1,0 +1,30 @@
+var Test = require('../../support/detectchildren-runner');
+
+describe('Detect Children :: ', function () {
+  it('should parse the child record correctly', function () {
+    Test({
+      primaryKeyAttr: 'childId',
+
+      records: [{
+        id: 1,
+        childId: '2',
+        'childId__id': '2',
+        'childId__a1__c1': 'a1',
+        'childId__a2__c1': 'a2'
+      }],
+      expected: {
+        parents: [{
+          id: 1,
+          childId: '2'
+        }],
+        children: {
+          childId: [{
+            id: '2',
+            'a1__c1': 'a1',
+            'a2__c1': 'a2'
+          }]
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
The attribute names aliases are incorrectly split, if the attribute name already 
contains '__', which is the pattern used for separating attributes from child tables.

Changed the implementation to resolve the name to the part post the first __.