### PR TITLE
Non-destructive alter migration strategy

### DIFF
--- a/lib/auto-migrations/private/run-alter-strategy/index.js
+++ b/lib/auto-migrations/private/run-alter-strategy/index.js
@@ -11,6 +11,8 @@
  * Module dependencies
  */
 
+var path = require('path');
+var util = require('util');
 var _ = require('@sailshq/lodash');
 var async = require('async');
 var flaverr = require('flaverr');
@@ -20,12 +22,11 @@ var informReFailedAlterStratagem = require('./private/inform-re-failed-alter-str
 /**
  * runAlterStrategy()
  *
- * Drop each table in the database and rebuild it with the new model definition,
- * coercing and reinserting the existing table data (if possible).
+ * Perform non-destructive auto-migration: modify schema incrementally where safe,
+ * warn about incompatibilities, and never drop data unless absolutely necessary.
  *
- * @param  {[type]}   orm [description]
- * @param  {Function} cb  [description]
- * @return {[type]}       [description]
+ * @param  {Ref}   orm
+ * @param  {Function} cb
  */
 module.exports = function runAlterStrategy(orm, cb) {
   // Refuse to run this migration strategy in production.
@@ -33,10 +34,6 @@ module.exports = function runAlterStrategy(orm, cb) {
     return cb(new Error('`migrate: \'alter\'` strategy is not supported in production, please change to `migrate: \'safe\'`.'));
   }
 
-  // The alter strategy works by looping through each collection in the ORM and
-  // pulling out the data that is currently in the database and keeping it in
-  // memory. It then drops the table and rebuilds it based on the collection's
-  // schema definition and the `autoMigrations` settings on the attributes.
   async.each(_.keys(orm.collections), function simultaneouslyMigrateEachModel(modelIdentity, next) {
     var WLModel = orm.collections[modelIdentity];
 
@@ -51,15 +48,12 @@ module.exports = function runAlterStrategy(orm, cb) {
     var tableDDLSpec = {};
     try {
       _.each(WLModel.schema, function parseAttribute(wlsAttrDef, wlsAttrName) {
-        // If this is a plural association, then skip it.
-        // (it is impossible for a key from this error to match up with one of these-- they don't even have column names)
         if (wlsAttrDef.collection) {
           return;
         }
 
         var columnName = wlsAttrDef.columnName;
 
-        // If the attribute doesn't have an `autoMigrations` key on it, throw an error.
         if (!_.has(wlsAttrDef, 'autoMigrations')) {
           throw new Error('An attribute in the model definition: `' + wlsAttrName + '` is missing an `autoMigrations` property. When running the `alter` migration, each attribute must have an autoMigrations key so that you don\'t end up with an invalid data schema.');
         }
@@ -78,132 +72,19 @@ module.exports = function runAlterStrategy(orm, cb) {
       tableDDLSpec[pkColumnName].primaryKey = true;
     }
 
-    // Make sure that the backup data is sorted by primary key (if the model has one).
-    var sort = primaryKey ? primaryKeyAttrName + ' ASC' : [];
+    // ---------------------------------------------------------------
+    // Decide strategy based on whether the adapter supports describe()
+    // ---------------------------------------------------------------
 
-    //  ╔═╗╔═╗╔╦╗  ┌┐ ┌─┐┌─┐┬┌─┬ ┬┌─┐  ┌┬┐┌─┐┌┬┐┌─┐
-    //  ║ ╦║╣  ║   ├┴┐├─┤│  ├┴┐│ │├─┘   ││├─┤ │ ├─┤
-    //  ╚═╝╚═╝ ╩   └─┘┴ ┴└─┘┴ ┴└─┘┴    ─┴┘┴ ┴ ┴ ┴ ┴
-    WLModel.find()
-    .meta({
-      skipAllLifecycleCallbacks: true,
-      skipRecordVerification: true,
-      decrypt: true,
-      skipExpandingDefaultSelectClause: true
-    })
-    .sort(sort)
-    .exec(function findCallback(err, backupRecords) {
-      if (err) {
-        // Ignore the error if it's an adapter error.  For example, this could error out
-        // on an empty database when the table doesn't yet exist (which is perfectly fine).
-        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        // FUTURE: further negotiate this error and only ignore failure due to "no such table"
-        // (other errors are still relevant and important).  The database-specific piece of
-        // this should happen in the adapter (and where supported, use a newly standardized
-        // footprint from the underlying driver)
-        // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-        if (err.name === 'AdapterError') {
+    if (_.isFunction(WLAdapter.describe)) {
+      // Adapter has describe() — use incremental migration (e.g. MySQL)
+      return migrateWithDescribe(WLAdapter, datastoreName, tableName, tableDDLSpec, WLModel, primaryKeyAttrName, next);
+    }
 
-          // Ignore.
-          //
-          // (But note that we also set backupRecords to an empty array so that it matches
-          // what we'd expect if everything had worked out.)
-          backupRecords = [];
+    // Adapter lacks describe() (e.g. MongoDB) — just ensure indexes,
+    // never drop the collection.
+    return migrateWithoutDescribe(WLAdapter, datastoreName, tableName, tableDDLSpec, next);
 
-        // But otherwise, this is NOT an adapter error, so still bail w/ a fatal error
-        // (because this means something else completely unexpected has happened.)
-        } else {
-          return next(flaverr({
-            message: 'When attempting to perform the `alter` auto-migration strategy '+
-            'on model `' + WLModel.identity + '`, Sails encountered an error.  '+err.message+'\n'+
-            'Tip: Could there be existing records in the database that are not compatible '+
-            'with a recent change to this model\'s definition?  If so, you might need to '+
-            'migrate them manually or, if you don\'t care about the data, wipe them; e.g. --drop.\n'+
-            '--\n'+
-            'For help with auto-migrations, visit:\n'+
-            ' [?] https://sailsjs.com/docs/concepts/models-and-orm/model-settings#?migrate\n'
-          }, err));
-        }
-      }//>-•
-
-      //  ╔╦╗╦═╗╔═╗╔═╗  ┌┬┐┌─┐┌┐ ┬  ┌─┐
-      //   ║║╠╦╝║ ║╠═╝   │ ├─┤├┴┐│  ├┤
-      //  ═╩╝╩╚═╚═╝╩     ┴ ┴ ┴└─┘┴─┘└─┘
-      WLAdapter.drop(datastoreName, tableName, undefined, function dropCallback(err) {
-        if (err) {
-          informReFailedAlterStratagem(err, 'drop', WLModel.identity, backupRecords, next);//_∏_
-          return;
-        }//-•
-
-        //  ╔╦╗╔═╗╔═╗╦╔╗╔╔═╗  ┌┬┐┌─┐┌┐ ┬  ┌─┐
-        //   ║║║╣ ╠╣ ║║║║║╣    │ ├─┤├┴┐│  ├┤
-        //  ═╩╝╚═╝╚  ╩╝╚╝╚═╝   ┴ ┴ ┴└─┘┴─┘└─┘
-        WLAdapter.define(datastoreName, tableName, tableDDLSpec, function defineCallback(err) {
-          if (err) {
-            informReFailedAlterStratagem(err, 'define', WLModel.identity, backupRecords, next);//_∏_
-            return;
-          }//-•
-
-          //  ╦═╗╔═╗  ╦╔╗╔╔═╗╔═╗╦═╗╔╦╗  ┬─┐┌─┐┌─┐┌─┐┬─┐┌┬┐┌─┐
-          //  ╠╦╝║╣───║║║║╚═╗║╣ ╠╦╝ ║   ├┬┘├┤ │  │ │├┬┘ ││└─┐
-          //  ╩╚═╚═╝  ╩╝╚╝╚═╝╚═╝╩╚═ ╩   ┴└─└─┘└─┘└─┘┴└──┴┘└─┘
-          WLModel.createEach(backupRecords)
-          .meta({
-            skipAllLifecycleCallbacks: true
-          })
-          .exec(function createEachCallback(err) {
-            if (err) {
-              informReFailedAlterStratagem(err, 'createEach', WLModel.identity, backupRecords, next);//_∏_
-              return;
-            }//-•
-
-            //  ╔═╗╔═╗╔╦╗  ┌─┐┌─┐┌─┐ ┬ ┬┌─┐┌┐┌┌─┐┌─┐
-            //  ╚═╗║╣  ║   └─┐├┤ │─┼┐│ │├┤ ││││  ├┤
-            //  ╚═╝╚═╝ ╩   └─┘└─┘└─┘└└─┘└─┘┘└┘└─┘└─┘
-            // If this primary key attribute is not auto-incrementing, it won't have
-            // a sequence attached.  So we can skip it.
-            if (WLModel.schema[primaryKeyAttrName].autoMigrations.autoIncrement !== true) {
-              return next();
-            }
-
-            // If there were no pre-existing records, we can also skip this step,
-            // since the previous sequence number ought to be fine.
-            if (backupRecords.length === 0) {
-              return next();
-            }
-
-            // Otherwise, this model's primary key is auto-incrementing, so we'll expect
-            // the adapter to have a setSequence method.
-            if (!_.has(WLAdapter, 'setSequence')) {
-              // If it doesn't, log a warning, then skip setting the sequence number.
-              console.warn('\n' +
-                'Warning: Although `autoIncrement: true` was specified for the primary key\n' +
-                'of this model (`' + WLModel.identity + '`), this adapter does not support the\n' +
-                '`setSequence()` method, so the sequence number cannot be reset during the\n' +
-                'auto-migration process.\n' +
-                '(Proceeding without resetting the auto-increment sequence...)\n'
-              );
-              return next();
-            }
-
-
-            // Now try to reset the sequence so that the next record created has a reasonable ID.
-            var lastRecord = _.last(backupRecords);
-            var primaryKeyColumnName = WLModel.schema[primaryKeyAttrName].columnName;
-            var sequenceName = WLModel.tableName + '_' + primaryKeyColumnName + '_seq';
-            var sequenceValue = lastRecord[primaryKeyColumnName];
-
-            WLAdapter.setSequence(datastoreName, sequenceName, sequenceValue, function setSequenceCb(err) {
-              if (err) {
-                return next(err);
-              }
-
-              return next();
-            });//</ setSequence >
-          });//</ createEach >
-        });//</ define >
-      });//</ drop >
-    });//</ find >
   }, function afterMigrate(err) {
     if (err) {
       return cb(err);
@@ -212,3 +93,351 @@ module.exports = function runAlterStrategy(orm, cb) {
     return cb();
   });
 };
+
+
+/**
+ * migrateWithoutDescribe()
+ *
+ * For schemaless adapters like MongoDB that don't implement describe().
+ * Just call define() to ensure indexes exist. Never drop the collection.
+ *
+ * @param {Ref} WLAdapter
+ * @param {String} datastoreName
+ * @param {String} tableName
+ * @param {Dictionary} tableDDLSpec
+ * @param {Function} done
+ */
+function migrateWithoutDescribe(WLAdapter, datastoreName, tableName, tableDDLSpec, done) {
+  WLAdapter.define(datastoreName, tableName, tableDDLSpec, function defineCallback(err) {
+    if (err) {
+      // Only warn for constraint-related failures (e.g. duplicate key for unique index).
+      // Propagate real errors (connection, auth, etc.) as fatal.
+      if (err.name === 'AdapterError') {
+        console.warn('\n'+
+          'Warning: When performing `alter` auto-migration on `' + tableName + '`,\n'+
+          'the adapter could not apply all schema constraints (e.g. unique indexes).\n'+
+          'This usually means existing data violates a new uniqueness constraint.\n'+
+          'You may need to resolve duplicates manually.\n'+
+          '\n'+
+          'Error details:\n'+
+          '```\n'+
+          (err.message || util.inspect(err))+'\n'+
+          '```\n'
+        );
+        return done();
+      }
+      return done(err);
+    }
+
+    return done();
+  });
+}
+
+
+/**
+ * migrateWithDescribe()
+ *
+ * For schema-aware adapters like MySQL that implement describe().
+ * Checks current schema, and if the table exists with a compatible schema,
+ * avoids dropping it. Falls back to drop+reinsert only when necessary.
+ *
+ * @param {Ref} WLAdapter
+ * @param {String} datastoreName
+ * @param {String} tableName
+ * @param {Dictionary} tableDDLSpec
+ * @param {Ref} WLModel
+ * @param {String} primaryKeyAttrName
+ * @param {Function} done
+ */
+function migrateWithDescribe(WLAdapter, datastoreName, tableName, tableDDLSpec, WLModel, primaryKeyAttrName, done) {
+
+  WLAdapter.describe(datastoreName, tableName, function describeCallback(err, existingSchema) {
+    if (err) {
+      // Only treat "no such table" as recoverable. For that, adapters typically
+      // return an AdapterError or an empty/null schema. Real errors (connection,
+      // permissions) should propagate.
+      if (err.name === 'AdapterError') {
+        WLAdapter.define(datastoreName, tableName, tableDDLSpec, function(defineErr) {
+          if (defineErr) { return done(defineErr); }
+          return done();
+        });
+        return;
+      }
+      return done(err);
+    }
+
+    // If describe() returned nothing/empty, the table doesn't exist yet.
+    if (!existingSchema || _.keys(existingSchema).length === 0) {
+      WLAdapter.define(datastoreName, tableName, tableDDLSpec, function(err) {
+        if (err) { return done(err); }
+        return done();
+      });
+      return;
+    }
+
+    // Table exists. Check if schema changes are additive-only (safe).
+    var newColumns = [];
+    var warnings = [];
+
+    _.each(tableDDLSpec, function(spec, columnName) {
+      if (!existingSchema[columnName]) {
+        newColumns.push(columnName);
+      }
+    });
+
+    _.each(existingSchema, function(existingColDef, columnName) {
+      if (!tableDDLSpec[columnName]) {
+        warnings.push('Column `' + columnName + '` exists in the database but is no longer in the model. It will be left in place.');
+      }
+    });
+
+    if (warnings.length > 0) {
+      console.warn('\n'+
+        'Auto-migration warnings for `' + tableName + '`:\n'+
+        warnings.map(function(w) { return '  - ' + w; }).join('\n') + '\n'
+      );
+    }
+
+    // If there are new columns, we need to rebuild the table because
+    // the adapter interface doesn't expose ALTER TABLE directly.
+    // Fall back to the safe drop+reinsert with JSON backup.
+    if (newColumns.length > 0) {
+      return fallbackDropAndReinsert(WLAdapter, datastoreName, tableName, tableDDLSpec, WLModel, primaryKeyAttrName, done);
+    }
+
+    // Schema is compatible (no new columns needed). Just ensure indexes
+    // by calling define() — most adapters handle "IF NOT EXISTS" internally.
+    WLAdapter.define(datastoreName, tableName, tableDDLSpec, function defineCallback(err) {
+      if (err) {
+        // define() failed on an existing table. Warn rather than triggering
+        // a destructive fallback — dropping and reinserting would likely
+        // hit the same error again (e.g. duplicate key for a new unique index).
+        console.warn('\n'+
+          'Warning: When performing `alter` auto-migration on `' + tableName + '`,\n'+
+          'the adapter could not apply all schema constraints.\n'+
+          'You may need to resolve this manually.\n'+
+          '\n'+
+          'Error details:\n'+
+          '```\n'+
+          (err.message || util.inspect(err))+'\n'+
+          '```\n'
+        );
+      }
+
+      return done();
+    });
+  });
+}
+
+
+/**
+ * fallbackDropAndReinsert()
+ *
+ * The old-style drop+reinsert approach, but with a JSON backup written first.
+ * Used only when non-destructive migration isn't possible (e.g. new columns
+ * need to be added and the adapter doesn't support ALTER TABLE).
+ *
+ * @param {Ref} WLAdapter
+ * @param {String} datastoreName
+ * @param {String} tableName
+ * @param {Dictionary} tableDDLSpec
+ * @param {Ref} WLModel
+ * @param {String} primaryKeyAttrName
+ * @param {Function} done
+ */
+function fallbackDropAndReinsert(WLAdapter, datastoreName, tableName, tableDDLSpec, WLModel, primaryKeyAttrName, done) {
+
+  var primaryKey = WLModel.schema[primaryKeyAttrName];
+  var sort = primaryKey ? primaryKeyAttrName + ' ASC' : [];
+
+  //  ╔═╗╔═╗╔╦╗  ┌┐ ┌─┐┌─┐┬┌─┬ ┬┌─┐  ┌┬┐┌─┐┌┬┐┌─┐
+  //  ║ ╦║╣  ║   ├┴┐├─┤│  ├┴┐│ │├─┘   ││├─┤ │ ├─┤
+  //  ╚═╝╚═╝ ╩   └─┘┴ ┴└─┘┴ ┴└─┘┴    ─┴┘┴ ┴ ┴ ┴ ┴
+  WLModel.find()
+  .meta({
+    skipAllLifecycleCallbacks: true,
+    skipRecordVerification: true,
+    decrypt: true,
+    skipExpandingDefaultSelectClause: true
+  })
+  .sort(sort)
+  .exec(function findCallback(err, backupRecords) {
+    if (err) {
+      if (err.name === 'AdapterError') {
+        backupRecords = [];
+      } else {
+        return done(flaverr({
+          message: 'When attempting to perform the `alter` auto-migration strategy '+
+          'on model `' + WLModel.identity + '`, Sails encountered an error.  '+err.message+'\n'+
+          'Tip: Could there be existing records in the database that are not compatible '+
+          'with a recent change to this model\'s definition?  If so, you might need to '+
+          'migrate them manually or, if you don\'t care about the data, wipe them; e.g. --drop.\n'+
+          '--\n'+
+          'For help with auto-migrations, visit:\n'+
+          ' [?] https://sailsjs.com/docs/concepts/models-and-orm/model-settings#?migrate\n'
+        }, err));
+      }
+    }//>-•
+
+    // Write a JSON backup BEFORE dropping. Abort if backup fails —
+    // proceeding without a backup risks irreversible data loss.
+    writeJsonBackup(WLModel.identity, backupRecords, function(backupErr) {
+      if (backupErr) {
+        return done(flaverr({
+          message: 'When attempting to perform the `alter` auto-migration strategy '+
+          'on model `' + WLModel.identity + '`, Sails could not write the JSON backup '+
+          'required before the fallback drop-and-reinsert step. Aborting migration '+
+          'before dropping data to avoid irreversible data loss.\n'+
+          'Original error: ' + backupErr.message
+        }, backupErr));
+      }
+
+      //  ╔╦╗╦═╗╔═╗╔═╗  ┌┬┐┌─┐┌┐ ┬  ┌─┐
+      //   ║║╠╦╝║ ║╠═╝   │ ├─┤├┴┐│  ├┤
+      //  ═╩╝╩╚═╚═╝╩     ┴ ┴ ┴└─┘┴─┘└─┘
+      WLAdapter.drop(datastoreName, tableName, undefined, function dropCallback(err) {
+        if (err) {
+          informReFailedAlterStratagem(err, 'drop', WLModel.identity, backupRecords, done);//_∏_
+          return;
+        }//-•
+
+        //  ╔╦╗╔═╗╔═╗╦╔╗╔╔═╗  ┌┬┐┌─┐┌┐ ┬  ┌─┐
+        //   ║║║╣ ╠╣ ║║║║║╣    │ ├─┤├┴┐│  ├┤
+        //  ═╩╝╚═╝╚  ╩╝╚╝╚═╝   ┴ ┴ ┴└─┘┴─┘└─┘
+        WLAdapter.define(datastoreName, tableName, tableDDLSpec, function defineCallback(err) {
+          if (err) {
+            informReFailedAlterStratagem(err, 'define', WLModel.identity, backupRecords, done);//_∏_
+            return;
+          }//-•
+
+          // If no backup records, we're done.
+          if (backupRecords.length === 0) {
+            return done();
+          }
+
+          //  ╦═╗╔═╗  ╦╔╗╔╔═╗╔═╗╦═╗╔╦╗  ┬─┐┌─┐┌─┐┌─┐┬─┐┌┬┐┌─┐
+          //  ╠╦╝║╣───║║║║╚═╗║╣ ╠╦╝ ║   ├┬┘├┤ │  │ │├┬┘ ││└─┐
+          //  ╩╚═╚═╝  ╩╝╚╝╚═╝╚═╝╩╚═ ╩   ┴└─└─┘└─┘└─┘┴└──┴┘└─┘
+
+          // Sanitize backup records: strip keys not in the model,
+          // so that removed attributes don't cause createEach to fail.
+          var sanitizedRecords = sanitizeRecords(backupRecords, WLModel);
+
+          WLModel.createEach(sanitizedRecords)
+          .meta({
+            skipAllLifecycleCallbacks: true
+          })
+          .exec(function createEachCallback(err) {
+            if (err) {
+              informReFailedAlterStratagem(err, 'createEach', WLModel.identity, backupRecords, done);//_∏_
+              return;
+            }//-•
+
+            //  ╔═╗╔═╗╔╦╗  ┌─┐┌─┐┌─┐ ┬ ┬┌─┐┌┐┌┌─┐┌─┐
+            //  ╚═╗║╣  ║   └─┐├┤ │─┼┐│ │├┤ ││││  ├┤
+            //  ╚═╝╚═╝ ╩   └─┘└─┘└─┘└└─┘└─┘┘└┘└─┘└─┘
+            if (WLModel.schema[primaryKeyAttrName].autoMigrations.autoIncrement !== true) {
+              return done();
+            }
+
+            if (backupRecords.length === 0) {
+              return done();
+            }
+
+            if (!_.has(WLAdapter, 'setSequence')) {
+              console.warn('\n' +
+                'Warning: Although `autoIncrement: true` was specified for the primary key\n' +
+                'of this model (`' + WLModel.identity + '`), this adapter does not support the\n' +
+                '`setSequence()` method, so the sequence number cannot be reset during the\n' +
+                'auto-migration process.\n' +
+                '(Proceeding without resetting the auto-increment sequence...)\n'
+              );
+              return done();
+            }
+
+            // Use attribute name to read from logical records returned by find().
+            // Only fall back to columnName if the attribute name key isn't present.
+            var lastRecord = _.last(backupRecords);
+            var primaryKeyColumnName = WLModel.schema[primaryKeyAttrName].columnName;
+            var sequenceName = WLModel.tableName + '_' + primaryKeyColumnName + '_seq';
+            var sequenceValue = lastRecord[primaryKeyAttrName] !== undefined
+              ? lastRecord[primaryKeyAttrName]
+              : lastRecord[primaryKeyColumnName];
+
+            WLAdapter.setSequence(datastoreName, sequenceName, sequenceValue, function setSequenceCb(err) {
+              if (err) {
+                return done(err);
+              }
+
+              return done();
+            });//</ setSequence >
+          });//</ createEach >
+        });//</ define >
+      });//</ drop >
+    });//</ writeJsonBackup >
+  });//</ find >
+}
+
+
+/**
+ * sanitizeRecords()
+ *
+ * Strip keys from backup records that are not in the current model definition.
+ * This prevents createEach from failing when columns have been removed.
+ *
+ * @param {Array} records
+ * @param {Ref} WLModel
+ * @returns {Array} sanitized records
+ */
+function sanitizeRecords(records, WLModel) {
+  var validAttrNames = _.keys(WLModel.attributes);
+
+  return _.map(records, function(record) {
+    var sanitized = {};
+    _.each(record, function(val, key) {
+      if (_.contains(validAttrNames, key)) {
+        sanitized[key] = val;
+      }
+    });
+    return sanitized;
+  });
+}
+
+
+/**
+ * writeJsonBackup()
+ *
+ * Write a machine-readable JSON backup of records before a destructive migration.
+ *
+ * @param {String} modelIdentity
+ * @param {Array} records
+ * @param {Function} done
+ */
+function writeJsonBackup(modelIdentity, records, done) {
+  if (records.length === 0) {
+    return done();
+  }
+
+  // Don't write backups in the browser
+  if (typeof window !== 'undefined') {
+    return done();
+  }
+
+  var timeSeriesUniqueishSuffixPiece = Math.floor((Date.now()%10000000)/1000);
+  var relPath = '.tmp/automigration-backup.' + modelIdentity + '.' + timeSeriesUniqueishSuffixPiece + '.json';
+  var absPath = path.resolve(relPath);
+
+  try {
+    var fsx = require('fs-extra');
+    var content = JSON.stringify(records, null, 2);
+    fsx.outputFile(absPath, content, function(err) {
+      if (err) {
+        return done(err);
+      }
+      console.log('Auto-migration: wrote JSON backup of `' + modelIdentity + '` (' + records.length + ' records) to ' + relPath);
+      return done();
+    });
+  } catch (e) {
+    return done(e);
+  }
+}

--- a/lib/auto-migrations/private/run-alter-strategy/private/inform-re-failed-alter-stratagem.js
+++ b/lib/auto-migrations/private/run-alter-strategy/private/inform-re-failed-alter-stratagem.js
@@ -30,7 +30,7 @@ module.exports = function informReFailedAlterStratagem(err, operationName, model
   // Determine the path for the log file where we'll save these backup records.
   // (note that currently, we resolve the path relative to CWD)
   var timeSeriesUniqueishSuffixPiece = Math.floor((Date.now()%10000000)/1000);
-  var relPathToLogFile = '.tmp/automigration.'+modelIdentity+'.'+timeSeriesUniqueishSuffixPiece+'.log';
+  var relPathToLogFile = '.tmp/automigration.'+modelIdentity+'.'+timeSeriesUniqueishSuffixPiece+'.json';
   var absPathToLogFile = path.resolve(relPathToLogFile);
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // FUTURE: Expect app path (e.g. `sails.config.appPath`) as another required argument to
@@ -141,29 +141,31 @@ module.exports = function informReFailedAlterStratagem(err, operationName, model
   console.error(message);
 
 
-  // Now we'll build some suppementary logs:
-  var logFileContents = '';
-  logFileContents += 'On '+(new Date())+', Sails attempted to auto-migrate\n';
-  logFileContents += 'using the `alter` strategy, but was unable to transform all of your\n';
-  logFileContents += 'existing development data automatically.  This temporary file was created \n';
-  logFileContents += 'for your convenience, as a way of holding on to the unmigrated records that\n';
-  logFileContents += 'were originally stored in the `' + modelIdentity + '` model.\n';
-  logFileContents += '(Otherwise, this data would have been lost forever.)\n';
-  logFileContents += '\n';
-  logFileContents += '================================\n';
-  logFileContents += 'Recovered data (`' + modelIdentity + '`):\n';
-  logFileContents += '================================\n';
-  logFileContents += '\n';
-  logFileContents += util.inspect(backupRecords, { depth: 5 })+'\n';
-  logFileContents += '\n';
-  logFileContents += '\n';
-  logFileContents += '--\n';
-  logFileContents += 'For help with auto-migrations, visit:\n';
-  logFileContents += 'http://sailsjs.com/docs/concepts/models-and-orm/model-settings#?migrate\n';
-  logFileContents += '\n';
-  logFileContents += 'For questions, additional resources, or to talk to a human, visit:\n';
-  logFileContents += 'http://sailsjs.com/support\n';
-  logFileContents += '\n';
+  // Build machine-readable JSON backup of the records.
+  var logFileContents;
+  try {
+    logFileContents = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      model: modelIdentity,
+      operation: operationName,
+      recordCount: backupRecords.length,
+      records: backupRecords
+    }, null, 2);
+  } catch (jsonErr) {
+    // If JSON.stringify fails (e.g. circular refs), wrap the inspect output
+    // in a JSON envelope so the file remains machine-readable.
+    logFileContents = JSON.stringify({
+      timestamp: new Date().toISOString(),
+      model: modelIdentity,
+      operation: operationName,
+      recordCount: backupRecords.length,
+      jsonSerializationError: {
+        message: jsonErr && jsonErr.message,
+        stack: jsonErr && jsonErr.stack
+      },
+      inspectFallback: util.inspect(backupRecords, { depth: 5 })
+    }, null, 2);
+  }
 
   // And we'll write them.  (Where?  It depends.)
   (function(proceed){


### PR DESCRIPTION
## Summary

The current `alter` migration strategy drops tables/collections before re-inserting records. When re-insert fails (validation constraints reject existing data), data is already destroyed. This PR replaces the destructive cycle with a safe, incremental approach.

- **MongoDB (no `describe()`):** Calls `define()` for indexes only, never drops the collection. Records stay in place.
- **MySQL (has `describe()`):** Diffs old vs new schema. Skips drop when schema is compatible. Falls back to drop+reinsert only when new columns are needed.
- **Fallback path:** Writes machine-readable JSON backup before dropping (not `util.inspect()` text). Sanitizes backup records (strips removed attributes) before re-insert.
- **Backup format:** Changed from `.log` with `util.inspect()` to `.json` with `JSON.stringify()` so recovery data is programmatically restorable.

## Test plan

- [ ] Run with sails-mongo: verify collections are NOT dropped during `alter` migration
- [ ] Run with sails-mysql: verify tables are NOT dropped when schema is unchanged
- [ ] Run with sails-mysql: verify fallback drop+reinsert works when new columns are added
- [ ] Verify JSON backup file is written to `.tmp/` before destructive operations
- [ ] Verify `migrate: 'drop'` still works as before (not affected by this change)
- [ ] Verify `migrate: 'safe'` still works as before (not affected by this change)

Related: balderdashy/waterline#1629